### PR TITLE
Bugfix/clear side drawer

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -35,7 +35,7 @@
             "varsIgnorePattern": "[_].*"
           }
         ],
-        "react-hooks/exhaustive-deps": ["error"],
+        "react-hooks/exhaustive-deps": ["warn"],
         "array-callback-return": ["error"],
         "@nrwl/nx/enforce-module-boundaries": ["warn"]
       }

--- a/packages/features/vault/src/vault-view/vault-action-side-drawer.tsx
+++ b/packages/features/vault/src/vault-view/vault-action-side-drawer.tsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+import { useContext, useEffect } from 'react';
 import { Drawer, SideBarSubHeader, PageLoading } from '@notional-finance/mui';
 import { Transition } from 'react-transition-group';
 import { Box, useTheme } from '@mui/material';
@@ -8,6 +8,7 @@ import { CreateVaultPosition, ManageVault } from '../side-drawers';
 import { VaultActionContext } from '../vault-view/vault-action-provider';
 import { defineMessage } from 'react-intl';
 import { useHistory } from 'react-router';
+import { useSideDrawerManager } from '@notional-finance/side-drawer';
 
 interface TransitionStyles {
   entering: Record<string, string | number>;
@@ -46,6 +47,12 @@ export const VaultActionSideDrawer = () => {
   const { accountSummariesLoaded } = useAccount();
   const { connected } = useOnboard();
   const { SideDrawerComponent, openDrawer } = useVaultSideDrawers();
+  const { clearSideDrawer } = useSideDrawerManager();
+
+  useEffect(() => {
+    clearSideDrawer();
+  }, [clearSideDrawer]);
+
   const {
     state: { vaultAddress, vaultAccount },
     updateState,

--- a/packages/features/vault/src/vault-view/vault-action-side-drawer.tsx
+++ b/packages/features/vault/src/vault-view/vault-action-side-drawer.tsx
@@ -51,7 +51,7 @@ export const VaultActionSideDrawer = () => {
 
   useEffect(() => {
     clearSideDrawer();
-  }, [clearSideDrawer]);
+  }, []);
 
   const {
     state: { vaultAddress, vaultAccount },

--- a/packages/shared/side-drawer/src/side-drawer-manager/use-side-drawer-manager.tsx
+++ b/packages/shared/side-drawer/src/side-drawer-manager/use-side-drawer-manager.tsx
@@ -76,8 +76,10 @@ export const useSideDrawerManager = () => {
     }
   };
 
-  const clearSideDrawer = (key: string) => {
-    history.push(key);
+  const clearSideDrawer = (key?: string) => {
+    if (key) {
+      history.push(key);
+    }
     updateSideDrawerState({
       sideDrawerOpen: false,
       currentSideDrawerKey: null,


### PR DESCRIPTION
- Small bug fix where the global side drawer was not being cleared when coming to the vault page from the portfolio page
- Change the error for useEffect exhaustive deps to a warning. There are many times when there is a valid reason for having a useEffect to run one time when a page loads. This is one of those