### PR TITLE
Bugfix/contest table bug

### DIFF
--- a/apps/web/src/containers/TradingContest/hooks/use-contest-rules-info.tsx
+++ b/apps/web/src/containers/TradingContest/hooks/use-contest-rules-info.tsx
@@ -33,13 +33,6 @@ export const useContestRulesInfo = () => {
     {
       text: (
         <FormattedMessage
-          defaultMessage={`Users can not deposit more than 1,000 USD. If the value of a user’s account grows while it’s on Notional and comes to exceed 1,000 USD, the user will not be disqualified. But users who push their account value over 1,000 USD by depositing will be disqualified.`}
-        />
-      ),
-    },
-    {
-      text: (
-        <FormattedMessage
           defaultMessage={`NOTE incentives are counted as earnings and will be converted to USD as of the average NOTE price over the course of the contest.`}
         />
       ),

--- a/packages/common/mui/src/lib/area-chart/area-chart.tsx
+++ b/packages/common/mui/src/lib/area-chart/area-chart.tsx
@@ -62,6 +62,19 @@ export interface AreaChartProps {
   title?: string;
 }
 
+export const yAxisTickHandler = (yAxisTickFormat, v: number) => {
+  if (yAxisTickFormat === 'percent' && typeof v === 'number') {
+    return formatNumberAsPercent(v);
+  }
+  if (yAxisTickFormat === 'usd' && typeof v === 'number') {
+    return `$${formatNumberToDigits(v, 2)}`;
+  }
+  if (yAxisTickFormat === 'number' && typeof v === 'number') {
+    return formatNumber(v, 2);
+  }
+  return `${v}`;
+};
+
 export const AreaChart = ({
   areaChartData,
   xAxisTickFormat = 'date',
@@ -79,24 +92,7 @@ export const AreaChart = ({
 }: AreaChartProps) => {
   const theme = useTheme();
 
-  const yAxisTickHandler = (yAxisTickFormat, v: number) => {
-    if (yAxisTickFormat === 'percent' && typeof v === 'number') {
-      return formatNumberAsPercent(v);
-    }
-    if (yAxisTickFormat === 'usd' && typeof v === 'number') {
-      return `$${formatNumberToDigits(v, 2)}`;
-    }
-    if (yAxisTickFormat === 'number' && typeof v === 'number') {
-      return formatNumber(v, 2);
-    }
-    return `${v}`;
-  };
-
-  const defaultChartToolTipData = useDefaultToolTips(
-    yAxisTickHandler,
-    yAxisTickFormat,
-    title
-  );
+  const defaultChartToolTipData = useDefaultToolTips(yAxisTickFormat, title);
 
   const xAxisTickHandler = (v: number, i: number) => {
     let result = '';

--- a/packages/common/mui/src/lib/area-chart/area-chart.tsx
+++ b/packages/common/mui/src/lib/area-chart/area-chart.tsx
@@ -59,6 +59,7 @@ export interface AreaChartProps {
   areaLineType?: 'linear' | 'monotone';
   emptyStateMessage?: ReactNode;
   showEmptyState?: boolean;
+  title?: string;
 }
 
 export const AreaChart = ({
@@ -74,10 +75,28 @@ export const AreaChart = ({
   isMultiChart,
   emptyStateMessage,
   showEmptyState,
+  title,
 }: AreaChartProps) => {
   const theme = useTheme();
 
-  const defaultChartToolTipData = useDefaultToolTips();
+  const yAxisTickHandler = (yAxisTickFormat, v: number) => {
+    if (yAxisTickFormat === 'percent' && typeof v === 'number') {
+      return formatNumberAsPercent(v);
+    }
+    if (yAxisTickFormat === 'usd' && typeof v === 'number') {
+      return `$${formatNumberToDigits(v, 2)}`;
+    }
+    if (yAxisTickFormat === 'number' && typeof v === 'number') {
+      return formatNumber(v, 2);
+    }
+    return `${v}`;
+  };
+
+  const defaultChartToolTipData = useDefaultToolTips(
+    yAxisTickHandler,
+    yAxisTickFormat,
+    title
+  );
 
   const xAxisTickHandler = (v: number, i: number) => {
     let result = '';
@@ -92,19 +111,6 @@ export const AreaChart = ({
       result = formatNumberAsPercent(v);
     }
     return result;
-  };
-
-  const yAxisTickHandler = (v: number) => {
-    if (yAxisTickFormat === 'percent' && typeof v === 'number') {
-      return formatNumberAsPercent(v);
-    }
-    if (yAxisTickFormat === 'usd' && typeof v === 'number') {
-      return `$${formatNumberToDigits(v, 2)}`;
-    }
-    if (yAxisTickFormat === 'number' && typeof v === 'number') {
-      return formatNumber(v, 2);
-    }
-    return `${v}`;
   };
 
   return (
@@ -188,7 +194,7 @@ export const AreaChart = ({
             tickLine={false}
             axisLine={false}
             style={{ fill: theme.palette.typography.light, fontSize: '12px' }}
-            tickFormatter={(v: number) => yAxisTickHandler(v)}
+            tickFormatter={(v: number) => yAxisTickHandler(yAxisTickFormat, v)}
           />
           <Line
             type="monotone"

--- a/packages/common/mui/src/lib/area-chart/use-default-tool-tips.tsx
+++ b/packages/common/mui/src/lib/area-chart/use-default-tool-tips.tsx
@@ -1,13 +1,14 @@
-import {
-  getDateString,
-  formatNumberAsPercent,
-} from '@notional-finance/helpers';
+import { getDateString } from '@notional-finance/helpers';
 import { useTheme } from '@mui/material';
 import { ChartToolTipDataProps } from '../chart-tool-tip/chart-tool-tip';
 import { FormattedMessage } from 'react-intl';
 import { LEGEND_LINE_TYPES } from '../chart-header/chart-header';
 
-export const useDefaultToolTips = () => {
+export const useDefaultToolTips = (
+  yAxisTickHandler,
+  yAxisTickFormat,
+  title
+) => {
   const theme = useTheme();
   const chartToolTipData: ChartToolTipDataProps = {
     timestamp: {
@@ -25,9 +26,10 @@ export const useDefaultToolTips = () => {
       lineType: LEGEND_LINE_TYPES.SOLID,
       formatTitle: (area) => (
         <FormattedMessage
-          defaultMessage={'{apy} APY'}
+          defaultMessage={'{value} {title}'}
           values={{
-            apy: <span>{formatNumberAsPercent(area)}</span>,
+            value: <span>{yAxisTickHandler(yAxisTickFormat, area)}</span>,
+            title: <span>{title}</span>,
           }}
         />
       ),

--- a/packages/common/mui/src/lib/area-chart/use-default-tool-tips.tsx
+++ b/packages/common/mui/src/lib/area-chart/use-default-tool-tips.tsx
@@ -3,12 +3,9 @@ import { useTheme } from '@mui/material';
 import { ChartToolTipDataProps } from '../chart-tool-tip/chart-tool-tip';
 import { FormattedMessage } from 'react-intl';
 import { LEGEND_LINE_TYPES } from '../chart-header/chart-header';
+import { yAxisTickHandler } from './area-chart';
 
-export const useDefaultToolTips = (
-  yAxisTickHandler,
-  yAxisTickFormat,
-  title
-) => {
+export const useDefaultToolTips = (yAxisTickFormat, title) => {
   const theme = useTheme();
   const chartToolTipData: ChartToolTipDataProps = {
     timestamp: {

--- a/packages/common/mui/src/lib/contest-table/contest-cells/custom-icon-cell.tsx
+++ b/packages/common/mui/src/lib/contest-table/contest-cells/custom-icon-cell.tsx
@@ -58,7 +58,6 @@ export const CustomIconCell = ({ cell }) => {
           position: 'absolute',
           borderRadius: theme.shape.borderRadius(),
           border: `1px solid ${theme.palette.primary.light}`,
-          marginTop: theme.spacing(12),
           transition: 'all 0.3s ease-in-out',
           opacity: showAlert ? 1 : 0,
         }}

--- a/packages/common/mui/src/lib/type-form/type-form.tsx
+++ b/packages/common/mui/src/lib/type-form/type-form.tsx
@@ -16,11 +16,11 @@ const FormWrapper = styled(Box)(
     z-index: 99;
     font-weight: bold;
     text-align: center;
-    bottom: 0;
+    top: 0;
     right: 0;
-    margin: 40px;
-    margin-right: 15px;
+    margin-right: 26px;
     margin-bottom: 150px;
+    margin-top: 110px;
     box-shadow: -2px 1px 24px rgba(20, 41, 102, 0.2), 0px 4px 16px rgba(29, 116, 119, 0.4);
     @media (max-width: 400px) {
       display: none;
@@ -81,7 +81,7 @@ export const TypeForm = () => {
     if (!typeFormSubmitted) {
       setHideOverallForm(false);
     }
-  }, 15000);
+  }, 5000);
   return (
     <FormWrapper>
       {!hideOverallForm && (

--- a/packages/features/borrow/src/borrow-fixed/hooks/use-borrow-fixed-multi-chart.tsx
+++ b/packages/features/borrow/src/borrow-fixed/hooks/use-borrow-fixed-multi-chart.tsx
@@ -19,8 +19,9 @@ export const useBorrowFixedMultiChart = () => {
   const {
     state: { deposit },
   } = context;
-  const { areaChartData, apyToolTipData, tvlToolTipData } =
-    useInteractiveMaturityChart(deposit?.currencyId);
+  const { areaChartData, apyToolTipData } = useInteractiveMaturityChart(
+    deposit?.currencyId
+  );
   const { selectedfCashId, onSelect } = useMaturitySelect(
     'Collateral',
     context
@@ -51,10 +52,10 @@ export const useBorrowFixedMultiChart = () => {
       Component: (
         <ChartContainer>
           <AreaChart
+            title="TVL"
             showCartesianGrid
             xAxisTickFormat="date"
             areaChartData={tvlData}
-            chartToolTipData={tvlToolTipData}
             areaLineType="linear"
             yAxisTickFormat="usd"
           />

--- a/packages/features/borrow/src/borrow-variable/components/borrow-variable-trade-summary.tsx
+++ b/packages/features/borrow/src/borrow-variable/components/borrow-variable-trade-summary.tsx
@@ -42,6 +42,7 @@ export const BorrowVariableTradeSummary = () => {
             Component: (
               <ChartContainer>
                 <AreaChart
+                  title={'APY'}
                   showCartesianGrid
                   xAxisTickFormat="date"
                   areaChartData={apyData}
@@ -56,6 +57,7 @@ export const BorrowVariableTradeSummary = () => {
             Component: (
               <ChartContainer>
                 <AreaChart
+                  title={'TVL'}
                   showCartesianGrid
                   xAxisTickFormat="date"
                   areaChartData={tvlData}

--- a/packages/features/lend/src/lend-fixed/hooks/use-lend-fixed-multi-chart.tsx
+++ b/packages/features/lend/src/lend-fixed/hooks/use-lend-fixed-multi-chart.tsx
@@ -19,8 +19,9 @@ export const useLendFixedMultiChart = () => {
   const {
     state: { deposit },
   } = context;
-  const { areaChartData, tvlToolTipData, apyToolTipData } =
-    useInteractiveMaturityChart(deposit?.currencyId);
+  const { areaChartData, apyToolTipData } = useInteractiveMaturityChart(
+    deposit?.currencyId
+  );
   const { selectedfCashId, onSelect } = useMaturitySelect(
     'Collateral',
     context
@@ -52,9 +53,9 @@ export const useLendFixedMultiChart = () => {
         <ChartContainer>
           <AreaChart
             showCartesianGrid
+            title="TVL"
             xAxisTickFormat="date"
             areaChartData={tvlData}
-            chartToolTipData={tvlToolTipData}
             areaLineType="linear"
             yAxisTickFormat="usd"
           />

--- a/packages/features/lend/src/lend-variable/components/lend-variable-trade-summary.tsx
+++ b/packages/features/lend/src/lend-variable/components/lend-variable-trade-summary.tsx
@@ -44,6 +44,7 @@ export const LendVariableTradeSummary = () => {
             Component: (
               <ChartContainer>
                 <AreaChart
+                  title="APY"
                   showCartesianGrid
                   xAxisTickFormat="date"
                   areaChartData={apyData}
@@ -58,6 +59,7 @@ export const LendVariableTradeSummary = () => {
             Component: (
               <ChartContainer>
                 <AreaChart
+                  title="TVL"
                   showCartesianGrid
                   xAxisTickFormat="date"
                   areaChartData={tvlData}

--- a/packages/features/liquidity/src/liquidity-variable/components/liquidity-variable-summary.tsx
+++ b/packages/features/liquidity/src/liquidity-variable/components/liquidity-variable-summary.tsx
@@ -43,6 +43,7 @@ export const LiquidityVariableSummary = () => {
             Component: (
               <ChartContainer>
                 <AreaChart
+                  title="APY"
                   showCartesianGrid
                   xAxisTickFormat="date"
                   areaChartData={apyData}
@@ -57,6 +58,7 @@ export const LiquidityVariableSummary = () => {
             Component: (
               <ChartContainer>
                 <AreaChart
+                  title="TVL"
                   showCartesianGrid
                   xAxisTickFormat="date"
                   yAxisTickFormat="usd"

--- a/packages/shared/trade/src/hooks/use-interactive-maturity-chart.tsx
+++ b/packages/shared/trade/src/hooks/use-interactive-maturity-chart.tsx
@@ -8,7 +8,6 @@ import { useFCashMarket } from '@notional-finance/notionable-hooks';
 import {
   getDateString,
   formatNumberAsPercent,
-  formatNumberToDigits,
 } from '@notional-finance/helpers';
 
 export const useInteractiveMaturityChart = (currencyId: number | undefined) => {
@@ -35,27 +34,6 @@ export const useInteractiveMaturityChart = (currencyId: number | undefined) => {
     textHeader: <FormattedMessage defaultMessage={'APY by Maturity'} />,
   };
 
-  const tvlToolTipData: ChartToolTipDataProps = {
-    timestamp: {
-      formatTitle: (timestamp: any) => (
-        <FormattedMessage
-          defaultMessage="Date: {date}"
-          values={{ date: getDateString(timestamp) }}
-        />
-      ),
-    },
-    area: {
-      lineColor: theme.palette.typography.accent,
-      lineType: LEGEND_LINE_TYPES.SOLID,
-      formatTitle: (area: any) => (
-        <FormattedMessage
-          defaultMessage="TVL: {rate}"
-          values={{ rate: `$${formatNumberToDigits(area)}` }}
-        />
-      ),
-    },
-  };
-
   const apyToolTipData: ChartToolTipDataProps = {
     timestamp: {
       formatTitle: (timestamp: any) => (
@@ -77,7 +55,7 @@ export const useInteractiveMaturityChart = (currencyId: number | undefined) => {
     },
   };
 
-  return { areaChartData, tvlToolTipData, apyToolTipData, chartHeaderData };
+  return { areaChartData, apyToolTipData, chartHeaderData };
 };
 
 export default useInteractiveMaturityChart;

--- a/packages/shared/trade/src/hooks/use-interest-rate-utilization-chart.tsx
+++ b/packages/shared/trade/src/hooks/use-interest-rate-utilization-chart.tsx
@@ -41,11 +41,23 @@ export const useInterestRateUtilizationChart = (
         },
         {
           timestamp: (primeCashCurve.kinkUtilization1 * 100) / RATE_PRECISION,
-          area: (primeCashCurve.kinkRate1 * 100) / RATE_PRECISION,
+          area:
+            actionType === 'borrow'
+              ? (primeCashCurve.kinkRate1 * 100) / RATE_PRECISION
+              : (primeCashCurve.kinkRate1 *
+                  primeCashCurve.kinkUtilization1 *
+                  100) /
+                (RATE_PRECISION * RATE_PRECISION),
         },
         {
           timestamp: (primeCashCurve.kinkUtilization2 * 100) / RATE_PRECISION,
-          area: (primeCashCurve.kinkRate2 * 100) / RATE_PRECISION,
+          area:
+            actionType === 'borrow'
+              ? (primeCashCurve.kinkRate2 * 100) / RATE_PRECISION
+              : (primeCashCurve.kinkRate2 *
+                  primeCashCurve.kinkUtilization2 *
+                  100) /
+                (RATE_PRECISION * RATE_PRECISION),
         },
         {
           timestamp: 100,
@@ -62,20 +74,6 @@ export const useInterestRateUtilizationChart = (
       ) : (
         <FormattedMessage defaultMessage={'Prime Lending Rate | Utilization'} />
       ),
-    legendData: [
-      {
-        label:
-          actionType === 'borrow' ? (
-            <FormattedMessage defaultMessage={'Prime Borrow Rate'} />
-          ) : (
-            <FormattedMessage defaultMessage={'Prime Lending Rate'} />
-          ),
-        // TODO: Add correct value here
-        value: '-',
-        lineColor: colors.blueAccent,
-        lineType: LEGEND_LINE_TYPES.SOLID,
-      },
-    ],
   };
 
   const chartToolTipData: ChartToolTipDataProps = {

--- a/packages/shared/trade/src/liquidation-chart/use-liquidation-chart.tsx
+++ b/packages/shared/trade/src/liquidation-chart/use-liquidation-chart.tsx
@@ -29,7 +29,7 @@ export function useLiquidationChart(
     debt,
     tradeType,
     priorAccountRisk,
-    canSubmit,
+    inputsSatisfied,
   } = state;
 
   const token =
@@ -151,6 +151,6 @@ export function useLiquidationChart(
     areaChartHeaderData,
     chartToolTipData,
     yAxisDomain,
-    showEmptyState: !canSubmit,
+    showEmptyState: !inputsSatisfied,
   };
 }

--- a/packages/shared/web/src/header/analytics-dropdown/use-analytics-dropdown.tsx
+++ b/packages/shared/web/src/header/analytics-dropdown/use-analytics-dropdown.tsx
@@ -27,7 +27,7 @@ export const useAnalyticsDropdown = () => {
     },
     {
       title: <FormattedMessage defaultMessage={'Dune Dashboard'} />,
-      to: 'https://dune.com/PierreYves_Gendron/Notional-V2-Dashboard',
+      to: 'https://dune.com/PierreYves_Gendron/notional-finance-v3',
       icon: (
         <DuneIcon
           sx={{


### PR DESCRIPTION
- Bug Fixed: Fill in inputs message persists after inputs have been filled in
- Bug Fixed: Leaderboard address copying gives you the wrong address
- Bug Fixed: When I browse over the Prime Lending graph the “Prime Lending Rate” displays the “Prime Borrow Rate”
- Bug Fixed: nToken TVL is denominated in % in the provide liquidity pages when I browse over the historical nToken TVL
- Bug Fixed: Busted link. Dune on the Arbitrum site