### PR TITLE
Bugfix/utilization chart updates

### DIFF
--- a/apps/web/src/containers/LandingPageView/components/stats-and-transparency/use-dashboard-links.tsx
+++ b/apps/web/src/containers/LandingPageView/components/stats-and-transparency/use-dashboard-links.tsx
@@ -25,7 +25,7 @@ export const useDashboardLinks = () => {
     },
     {
       title: 'Dune Dashboard',
-      link: 'https://dune.com/PierreYves_Gendron/Notional-V2-Dashboard',
+      link: 'https://dune.com/PierreYves_Gendron/notional-dashboard',
       image: dune,
       icon: (
         <DuneIcon

--- a/packages/common/mui/src/lib/area-chart/x-axis-tick/x-axis-tick.tsx
+++ b/packages/common/mui/src/lib/area-chart/x-axis-tick/x-axis-tick.tsx
@@ -41,7 +41,7 @@ export const XAxisTick = (props) => {
             })
           : ''}
         {xAxisTickFormat === 'percent' && typeof value === 'number'
-          ? formatNumberAsPercent(value)
+          ? formatNumberAsPercent(value, 0)
           : ''}
       </text>
     </g>

--- a/packages/common/mui/src/lib/card-variants/currency/currency.tsx
+++ b/packages/common/mui/src/lib/card-variants/currency/currency.tsx
@@ -48,7 +48,11 @@ export const Currency = (props: CurrencyProps) => {
                 sx={{ height: '1.5em', marginRight: theme.spacing(1) }}
               />
             )}
-            <H4 textAlign="left" marginBottom={theme.spacing(4)}>
+            <H4
+              textAlign="left"
+              marginBottom={theme.spacing(4)}
+              sx={{ color: rate < 0 ? colors.red : '' }}
+            >
               <FormattedMessage
                 defaultMessage="{formattedRate} APY"
                 values={{

--- a/packages/common/mui/src/lib/card-variants/incentive/incentive.tsx
+++ b/packages/common/mui/src/lib/card-variants/incentive/incentive.tsx
@@ -70,7 +70,11 @@ export const Incentive = ({
                 sx={{ height: '1.5em', marginRight: theme.spacing(1) }}
               />
             )}
-            <H4 textAlign="left" marginBottom={theme.spacing(4)}>
+            <H4
+              textAlign="left"
+              marginBottom={theme.spacing(4)}
+              sx={{ color: formattedTotalRate.includes('-') ? colors.red : '' }}
+            >
               {formattedTotalRate}
             </H4>
           </Box>
@@ -78,14 +82,24 @@ export const Incentive = ({
           <SectionTitle textAlign="left" marginBottom={theme.spacing(1)}>
             <FormattedMessage defaultMessage={'ORGANIC'} />
           </SectionTitle>
-          <CardInput textAlign="left" marginBottom={theme.spacing(3)}>
+          <CardInput
+            textAlign="left"
+            marginBottom={theme.spacing(3)}
+            sx={{ color: formattedRate.includes('-') ? colors.red : '' }}
+          >
             {formattedRate}
           </CardInput>
           <SectionTitle textAlign="left" marginBottom={theme.spacing(1)}>
             <PlusIcon width={'9px'} />
             <FormattedMessage defaultMessage="NOTE INCENTIVE" />
           </SectionTitle>
-          <CardInput textAlign="left" marginBottom={theme.spacing(3)}>
+          <CardInput
+            textAlign="left"
+            marginBottom={theme.spacing(3)}
+            sx={{
+              color: formattedIncentiveRate.includes('-') ? colors.red : '',
+            }}
+          >
             {formattedIncentiveRate}
           </CardInput>
         </>

--- a/packages/common/mui/src/lib/card-variants/vault/vault.tsx
+++ b/packages/common/mui/src/lib/card-variants/vault/vault.tsx
@@ -60,7 +60,10 @@ export const Vault = ({
             {vaultName}
           </SmallInput>
           <SectionTitle textAlign="left" gutter="default">
-            <FormattedMessage defaultMessage="{leverage} LEVERAGE" values={{ leverage }} />
+            <FormattedMessage
+              defaultMessage="{leverage} LEVERAGE"
+              values={{ leverage }}
+            />
           </SectionTitle>
           <Box sx={{ display: 'flex', alignItems: 'flex-start' }}>
             <LightningIcon
@@ -70,6 +73,7 @@ export const Vault = ({
               textAlign="left"
               marginBottom={theme.spacing(3)}
               fontWeight="bold"
+              sx={{ color: rate < 0 ? colors.red : '' }}
             >
               {formattedRate}
             </H4>

--- a/packages/common/mui/src/lib/chart-header/chart-header.tsx
+++ b/packages/common/mui/src/lib/chart-header/chart-header.tsx
@@ -88,8 +88,9 @@ export const ChartHeader = ({
         {chartHeaderData?.legendData &&
           chartHeaderData?.legendData.length > 0 &&
           chartHeaderData.legendData.map(
-            ({ value, label, lineColor, lineType }) => (
+            ({ value, label, lineColor, lineType }, index) => (
               <ChartLegend
+                key={index}
                 value={value}
                 label={label}
                 lineColor={lineColor}

--- a/packages/common/mui/src/lib/data-table/data-table-body/data-table-body.tsx
+++ b/packages/common/mui/src/lib/data-table/data-table-body/data-table-body.tsx
@@ -14,6 +14,7 @@ import {
   SmallTableCell,
   TableCell as TypographyTableCell,
 } from '../../typography/typography';
+import { useHistory } from 'react-router';
 
 interface StyledTableRowProps extends TableRowProps {
   theme: NotionalTheme;
@@ -109,6 +110,7 @@ export const DataTableBody = ({
   initialState,
 }: DataTableBodyProps) => {
   const theme = useTheme() as NotionalTheme;
+  const history = useHistory();
   return (
     <TableBody>
       {rows.map((row, i) => {
@@ -129,6 +131,12 @@ export const DataTableBody = ({
               [row.index]: !initialState?.expanded[row.index],
             };
             setExpandedRows(newState);
+          }
+          if (row.original.view) {
+            history.push(row.original.view);
+          }
+          if (row.original?.txLink?.href) {
+            window.open(row.original.txLink.href, '_blank');
           }
         };
 
@@ -151,6 +159,16 @@ export const DataTableBody = ({
             }
           : {};
 
+        const rowHoverStyles =
+          row.original.view || row.original?.txLink?.href
+            ? {
+                '&:hover': {
+                  background: theme.palette.info.light,
+                  cursor: 'pointer',
+                },
+              }
+            : {};
+
         return (
           <Fragment key={`row-container-${i}`}>
             <StyledTableRow
@@ -166,6 +184,7 @@ export const DataTableBody = ({
                   transition: 'all 0.3s ease',
                   background: theme.palette.info.light,
                 },
+                ...rowHoverStyles,
               }}
               {...row['getRowProps']()}
             >

--- a/packages/common/mui/src/lib/total-box/total-box.tsx
+++ b/packages/common/mui/src/lib/total-box/total-box.tsx
@@ -1,16 +1,26 @@
 import { Box, useTheme } from '@mui/material';
 import { ReactNode } from 'react';
 import { Body, LabelValue } from '../typography/typography';
+import CountUp from '../count-up/count-up';
 
 /* eslint-disable-next-line */
 export interface TotalBoxProps {
   title: ReactNode;
-  value?: string | number;
+  value?: number | string;
+  prefix?: string;
+  suffix?: string;
   Icon?: any;
 }
 
-export function TotalBox({ title, value, Icon }: TotalBoxProps) {
+export function TotalBox({
+  title,
+  value,
+  Icon,
+  suffix,
+  prefix,
+}: TotalBoxProps) {
   const theme = useTheme();
+
   return (
     <Box
       sx={{
@@ -35,7 +45,13 @@ export function TotalBox({ title, value, Icon }: TotalBoxProps) {
           />
         )}
       </Body>
-      <LabelValue>{value}</LabelValue>
+      <LabelValue>
+        {value !== undefined && typeof value === 'number' ? (
+          <CountUp value={value} prefix={prefix} suffix={suffix} duration={1} />
+        ) : (
+          value
+        )}
+      </LabelValue>
     </Box>
   );
 }

--- a/packages/features/borrow/src/borrow-fixed/components/borrow-fixed-trade-summary.tsx
+++ b/packages/features/borrow/src/borrow-fixed/components/borrow-fixed-trade-summary.tsx
@@ -41,8 +41,8 @@ export const BorrowFixedTradeSummary = () => {
           marginTop: theme.spacing(3),
         }}
       >
-        {totalsData.map(({ title, value }, index) => (
-          <TotalBox title={title} value={value} key={index} />
+        {totalsData.map(({ title, value, prefix }, index) => (
+          <TotalBox title={title} value={value} key={index} prefix={prefix} />
         ))}
       </Box>
 

--- a/packages/features/borrow/src/borrow-fixed/hooks/use-totals-data.tsx
+++ b/packages/features/borrow/src/borrow-fixed/hooks/use-totals-data.tsx
@@ -1,5 +1,5 @@
 import { FormattedMessage } from 'react-intl';
-import { TokenBalance } from '@notional-finance/core-entities';
+import { TokenBalance, FiatSymbols } from '@notional-finance/core-entities';
 import {
   useFiat,
   useAllMarkets,
@@ -36,13 +36,13 @@ export const useTotalsData = (selectedDepositToken: string | undefined) => {
   return [
     {
       title: <FormattedMessage defaultMessage={'TVL'} />,
-      value: tvlData?.toFiat(baseCurrency).toDisplayStringWithSymbol() || '-',
+      value: tvlData?.toFiat(baseCurrency).toFloat() || '-',
+      prefix: FiatSymbols[baseCurrency] ? FiatSymbols[baseCurrency] : '$',
     },
     {
       title: <FormattedMessage defaultMessage={'Total Fixed Rate Debt'} />,
-      value:
-        totalFixedRateDebt?.toFiat(baseCurrency).toDisplayStringWithSymbol() ||
-        '-',
+      value: totalFixedRateDebt?.toFiat(baseCurrency).toFloat() || '-',
+      prefix: FiatSymbols[baseCurrency] ? FiatSymbols[baseCurrency] : '$',
     },
     {
       title: <FormattedMessage defaultMessage={'Fixed Rate Borrowers'} />,

--- a/packages/features/borrow/src/borrow-variable/components/borrow-variable-trade-summary.tsx
+++ b/packages/features/borrow/src/borrow-variable/components/borrow-variable-trade-summary.tsx
@@ -77,8 +77,14 @@ export const BorrowVariableTradeSummary = () => {
           marginTop: theme.spacing(3),
         }}
       >
-        {totalsData.map(({ title, value }, index) => (
-          <TotalBox title={title} value={value} key={index} />
+        {totalsData.map(({ title, value, prefix, suffix }, index) => (
+          <TotalBox
+            title={title}
+            value={value}
+            key={index}
+            prefix={prefix}
+            suffix={suffix}
+          />
         ))}
       </Box>
       <Faq
@@ -111,7 +117,6 @@ export const BorrowVariableTradeSummary = () => {
                 </ChartContainer>
               ),
               chartHeaderData: chartHeaderData,
-              bottomLabel: <FormattedMessage defaultMessage={'Utilization'} />,
             },
           ]}
         />

--- a/packages/features/lend/src/lend-fixed/components/lend-fixed-trade-summary.tsx
+++ b/packages/features/lend/src/lend-fixed/components/lend-fixed-trade-summary.tsx
@@ -44,8 +44,8 @@ export const LendFixedTradeSummary = () => {
           marginTop: theme.spacing(3),
         }}
       >
-        {totalsData.map(({ title, value }, index) => (
-          <TotalBox title={title} value={value} key={index} />
+        {totalsData.map(({ title, value, prefix }, index) => (
+          <TotalBox title={title} value={value} key={index} prefix={prefix} />
         ))}
       </Box>
 

--- a/packages/features/lend/src/lend-fixed/hooks/use-totals-data.tsx
+++ b/packages/features/lend/src/lend-fixed/hooks/use-totals-data.tsx
@@ -1,5 +1,5 @@
 import { FormattedMessage } from 'react-intl';
-import { TokenBalance } from '@notional-finance/core-entities';
+import { TokenBalance, FiatSymbols } from '@notional-finance/core-entities';
 import {
   useFiat,
   useAllMarkets,
@@ -36,14 +36,13 @@ export const useTotalsData = (selectedDepositToken: string | undefined) => {
   return [
     {
       title: <FormattedMessage defaultMessage={'TVL'} />,
-      value:
-        tvlData?.tvl?.toFiat(baseCurrency).toDisplayStringWithSymbol() || '-',
+      value: tvlData?.tvl?.toFiat(baseCurrency).toFloat() || '-',
+      prefix: FiatSymbols[baseCurrency] ? FiatSymbols[baseCurrency] : '$',
     },
     {
       title: <FormattedMessage defaultMessage={'Total Fixed Rate Debt'} />,
-      value:
-        totalFixedRateDebt?.toFiat(baseCurrency).toDisplayStringWithSymbol() ||
-        '-',
+      value: totalFixedRateDebt?.toFiat(baseCurrency).toFloat() || '-',
+      prefix: FiatSymbols[baseCurrency] ? FiatSymbols[baseCurrency] : '$',
     },
     {
       title: <FormattedMessage defaultMessage={'Total Fixed Rate Lenders'} />,

--- a/packages/features/lend/src/lend-leveraged/lend-leveraged-card-view.tsx
+++ b/packages/features/lend/src/lend-leveraged/lend-leveraged-card-view.tsx
@@ -55,32 +55,35 @@ export function LendLeveragedCardView() {
             const maxYield = getMax(yields);
 
             return (
-              <Currency
-                key={index}
-                symbol={symbol}
-                rate={maxYield?.totalAPY || 0}
-                route={route}
-                returnTitle={
-                  <FormattedMessage
-                    defaultMessage="{leverage} Leverage"
-                    values={{
-                      leverage: formatLeverageRatio(
-                        maxYield?.leveraged?.leverageRatio || 0,
-                        2
-                      ),
-                    }}
-                  />
-                }
-                leveraged
-                buttonText={
-                  <FormattedMessage
-                    defaultMessage="Lend {underlying}"
-                    values={{
-                      underlying: symbol,
-                    }}
-                  />
-                }
-              />
+              maxYield?.totalAPY &&
+              maxYield?.totalAPY > 0 && (
+                <Currency
+                  key={index}
+                  symbol={symbol}
+                  rate={maxYield?.totalAPY || 0}
+                  route={route}
+                  returnTitle={
+                    <FormattedMessage
+                      defaultMessage="{leverage} Leverage"
+                      values={{
+                        leverage: formatLeverageRatio(
+                          maxYield?.leveraged?.leverageRatio || 0,
+                          2
+                        ),
+                      }}
+                    />
+                  }
+                  leveraged
+                  buttonText={
+                    <FormattedMessage
+                      defaultMessage="Lend {underlying}"
+                      values={{
+                        underlying: symbol,
+                      }}
+                    />
+                  }
+                />
+              )
             );
           })}
         </CardContainer>

--- a/packages/features/lend/src/lend-variable/components/lend-variable-trade-summary.tsx
+++ b/packages/features/lend/src/lend-variable/components/lend-variable-trade-summary.tsx
@@ -79,8 +79,14 @@ export const LendVariableTradeSummary = () => {
           marginTop: theme.spacing(3),
         }}
       >
-        {totalsData.map(({ title, value }, index) => (
-          <TotalBox title={title} value={value} key={index} />
+        {totalsData.map(({ title, value, prefix, suffix }, index) => (
+          <TotalBox
+            title={title}
+            value={value}
+            key={index}
+            prefix={prefix}
+            suffix={suffix}
+          />
         ))}
       </Box>
       {areaChartData.length > 0 && (
@@ -103,7 +109,6 @@ export const LendVariableTradeSummary = () => {
                 </ChartContainer>
               ),
               chartHeaderData: chartHeaderData,
-              bottomLabel: <FormattedMessage defaultMessage={'Utilization'} />,
             },
           ]}
         />

--- a/packages/features/liquidity/src/liquidity-variable/components/liquidity-variable-summary.tsx
+++ b/packages/features/liquidity/src/liquidity-variable/components/liquidity-variable-summary.tsx
@@ -78,8 +78,15 @@ export const LiquidityVariableSummary = () => {
           marginTop: theme.spacing(3),
         }}
       >
-        {totalsData.map(({ title, value, Icon }, index) => (
-          <TotalBox title={title} value={value} key={index} Icon={Icon} />
+        {totalsData.map(({ title, value, Icon, prefix, suffix }, index) => (
+          <TotalBox
+            title={title}
+            value={value}
+            key={index}
+            Icon={Icon}
+            prefix={prefix}
+            suffix={suffix}
+          />
         ))}
       </Box>
       <Faq

--- a/packages/features/liquidity/src/liquidity-variable/hooks/use-totals-data.tsx
+++ b/packages/features/liquidity/src/liquidity-variable/hooks/use-totals-data.tsx
@@ -1,8 +1,11 @@
 import { useAllMarkets, useFiat } from '@notional-finance/notionable-hooks';
-import { formatNumberAsPercent } from '@notional-finance/helpers';
 import { SparklesIcon } from '@notional-finance/icons';
 import { FormattedMessage } from 'react-intl';
-import { Registry, TokenBalance } from '@notional-finance/core-entities';
+import {
+  FiatSymbols,
+  Registry,
+  TokenBalance,
+} from '@notional-finance/core-entities';
 
 export const useTotalsData = (
   tokenSymbol: string,
@@ -17,20 +20,30 @@ export const useTotalsData = (
         ({ underlying }) => underlying.symbol === tokenSymbol
       );
 
+  if (liquidityData?.incentives && liquidityData?.incentives[0]?.incentiveAPY) {
+    console.log(
+      'liquidityData?.incentives[0]?.incentiveAPY: ',
+      liquidityData?.incentives[0]?.incentiveAPY
+    );
+  }
+
   return [
     {
       title: <FormattedMessage defaultMessage={'TVL'} />,
-      value:
-        liquidityData?.tvl?.toFiat(baseCurrency).toDisplayStringWithSymbol() ||
-        '-',
+      value: liquidityData?.tvl?.toFiat(baseCurrency).toFloat() || '-',
+      prefix: FiatSymbols[baseCurrency] ? FiatSymbols[baseCurrency] : '$',
     },
     {
       title: <FormattedMessage defaultMessage={'Incentive APY'} />,
       value:
         liquidityData?.incentives && liquidityData?.incentives[0]?.incentiveAPY
-          ? formatNumberAsPercent(liquidityData?.incentives[0]?.incentiveAPY)
+          ? liquidityData?.incentives[0]?.incentiveAPY
           : '-',
       Icon: SparklesIcon,
+      suffix:
+        liquidityData?.incentives && liquidityData?.incentives[0]?.incentiveAPY
+          ? '%'
+          : '',
     },
     {
       title: <FormattedMessage defaultMessage={'Liquidity Providers'} />,

--- a/packages/features/liquidity/src/liquidity-variable/hooks/use-totals-data.tsx
+++ b/packages/features/liquidity/src/liquidity-variable/hooks/use-totals-data.tsx
@@ -20,13 +20,6 @@ export const useTotalsData = (
         ({ underlying }) => underlying.symbol === tokenSymbol
       );
 
-  if (liquidityData?.incentives && liquidityData?.incentives[0]?.incentiveAPY) {
-    console.log(
-      'liquidityData?.incentives[0]?.incentiveAPY: ',
-      liquidityData?.incentives[0]?.incentiveAPY
-    );
-  }
-
   return [
     {
       title: <FormattedMessage defaultMessage={'TVL'} />,

--- a/packages/features/vault/src/messages.ts
+++ b/packages/features/vault/src/messages.ts
@@ -308,7 +308,7 @@ export const messages = {
       description: 'error message',
     },
     blockedGeoActionHelptext: {
-      defaultMessage: 'Leveraged products are not available in the US or to VPN users',
+      defaultMessage: 'Leveraged products are not available in the US or to VPN users. Non-Leveraged products are available to all users globally.',
       description: 'error message',
     },
   }),

--- a/packages/shared/trade/src/hooks/use-variable-totals.tsx
+++ b/packages/shared/trade/src/hooks/use-variable-totals.tsx
@@ -1,11 +1,11 @@
 import { FormattedMessage } from 'react-intl';
 import { TradeState } from '@notional-finance/notionable';
+import { FiatSymbols } from '@notional-finance/core-entities';
 import {
   useFiat,
   useCurrency,
   useTokenHistory,
 } from '@notional-finance/notionable-hooks';
-import { formatNumberAsPercent } from '@notional-finance/helpers';
 
 export const useVariableTotals = (state: TradeState) => {
   const isBorrow = state.tradeType === 'BorrowVariable';
@@ -31,23 +31,20 @@ export const useVariableTotals = (state: TradeState) => {
       ? lastSevenApys.reduce((a, b) => a + b) / lastSevenApys.length
       : 0;
 
-    return formatNumberAsPercent(averageApy);
+    return averageApy;
   };
 
   return [
     {
       title: <FormattedMessage defaultMessage={'Total Lent'} />,
-      value:
-        totalLentData?.totalSupply
-          ?.toFiat(baseCurrency)
-          .toDisplayStringWithSymbol() || '-',
+      value: totalLentData?.totalSupply?.toFiat(baseCurrency).toFloat() || '-',
+      prefix: FiatSymbols[baseCurrency] ? FiatSymbols[baseCurrency] : '$',
     },
     {
       title: <FormattedMessage defaultMessage={'Total Borrowed'} />,
       value:
-        totalBorrowedData?.totalSupply
-          ?.toFiat(baseCurrency)
-          .toDisplayStringWithSymbol() || '-',
+        totalBorrowedData?.totalSupply?.toFiat(baseCurrency).toFloat() || '-',
+      prefix: FiatSymbols[baseCurrency] ? FiatSymbols[baseCurrency] : '$',
     },
     {
       title: isBorrow ? (
@@ -56,6 +53,7 @@ export const useVariableTotals = (state: TradeState) => {
         <FormattedMessage defaultMessage={'Total Lenders'} />
       ),
       value: isBorrow ? getSevenDayAvgApy() : '-',
+      suffix: isBorrow ? '%' : '',
     },
   ];
 };

--- a/packages/shared/trade/src/transaction-confirmation/confirmation2.tsx
+++ b/packages/shared/trade/src/transaction-confirmation/confirmation2.tsx
@@ -67,7 +67,7 @@ export const Confirmation2 = ({
             a: (msg: string) => (
               <ExternalLink
                 href="/terms"
-                style={{ color: theme.palette.primary.accent }}
+                style={{ color: theme.palette.primary.light }}
               >
                 {msg}
               </ExternalLink>
@@ -131,7 +131,7 @@ const TermsOfService = styled(HeadingSubtitle)(
   ({ theme }) => `
   margin-top: ${theme.spacing(2)};
   margin-bottom: ${theme.spacing(3)};
-  color: ${theme.palette.borders.accentPaper};
+  color: ${theme.palette.typography.light};
 `
 );
 

--- a/packages/shared/trade/src/transaction-sidebar/transaction-sidebar.tsx
+++ b/packages/shared/trade/src/transaction-sidebar/transaction-sidebar.tsx
@@ -61,7 +61,7 @@ export const TransactionSidebar = ({
   const errorMessage = defineMessages({
     geoErrorHeading: {
       defaultMessage:
-        'Leveraged products are not available in the US or to VPN users',
+        'Leveraged products are not available in the US or to VPN users. Non-Leveraged products are available to all users globally.',
     },
   });
 

--- a/packages/shared/web/src/header/analytics-dropdown/use-analytics-dropdown.tsx
+++ b/packages/shared/web/src/header/analytics-dropdown/use-analytics-dropdown.tsx
@@ -27,7 +27,7 @@ export const useAnalyticsDropdown = () => {
     },
     {
       title: <FormattedMessage defaultMessage={'Dune Dashboard'} />,
-      to: 'https://dune.com/PierreYves_Gendron/notional-finance-v3',
+      to: 'https://dune.com/PierreYves_Gendron/notional-dashboard',
       icon: (
         <DuneIcon
           sx={{


### PR DESCRIPTION
- Updates lend and borrow variable utilization charts to display values by 10% increments
- Updates VPN and geo blocker message
- Adds CountUp to TotalBoxes
- Adds hover state to the rows of the Markets and Txn History tables  
- Adds links to product pages to Market table rows
- Adds hrefs to ether scan to Txn History table rows
- Updates negative values in product cards to be red
- Filters out negative value cards from the lend leveraged card page