### PR TITLE
Grab Bag

### DIFF
--- a/apps/web/src/containers/App/App.tsx
+++ b/apps/web/src/containers/App/App.tsx
@@ -6,6 +6,7 @@ import {
 import { TrackingConsent } from '@notional-finance/shared-web';
 import { Web3OnboardProvider } from '@web3-onboard/react';
 import { useEffect } from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
 import { Switch } from 'react-router';
 import { CompatRouter } from 'react-router-dom-v5-compat';
 import { ServerError } from '../ServerError/server-error';
@@ -232,6 +233,14 @@ export const App = () => {
     state: { themeVariant },
   } = globalState;
   const notionalTheme = useNotionalTheme(themeVariant);
+  const history = useHistory();
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    if (pathname.includes('contest')) {
+      history.push('/');
+    }
+  }, [pathname, history]);
 
   // Run as a useEffect here so that the observable "sees" the initial change
   useEffect(() => {

--- a/packages/features/portfolio/src/containers/portfolio-holdings/portfolio-holdings.tsx
+++ b/packages/features/portfolio/src/containers/portfolio-holdings/portfolio-holdings.tsx
@@ -22,7 +22,9 @@ export const PortfolioHoldings = () => {
       <DataTable
         toggleBarProps={toggleBarProps}
         data={
-          toggleBarProps.toggleOption === 0 ? groupedHoldings : detailedHoldings
+          toggleBarProps.toggleOption === 0 && toggleBarProps.showToggle
+            ? groupedHoldings
+            : detailedHoldings
         }
         pendingTokenData={pendingTokenData}
         pendingMessage={

--- a/packages/features/portfolio/src/containers/portfolio-holdings/use-portfolio-holdings.tsx
+++ b/packages/features/portfolio/src/containers/portfolio-holdings/use-portfolio-holdings.tsx
@@ -8,13 +8,17 @@ import {
   ChevronCell,
 } from '@notional-finance/mui';
 import { TotalEarningsTooltip } from '../../components';
-import { usePendingPnLCalculation } from '@notional-finance/notionable-hooks';
+import {
+  usePendingPnLCalculation,
+  useLeverageBlock,
+} from '@notional-finance/notionable-hooks';
 import { useDetailedHoldings } from './use-detailed-holdings';
 import { useGroupedHoldings } from './use-grouped-holdings';
 import { useTheme } from '@mui/material';
 
 export function usePortfolioHoldings() {
   const theme = useTheme();
+  const isBlocked = useLeverageBlock();
   const [expandedRows, setExpandedRows] = useState<ExpandedRows | null>(null);
   const [toggleOption, setToggleOption] = useState<number>(0);
   const initialState = expandedRows !== null ? { expanded: expandedRows } : {};
@@ -111,7 +115,7 @@ export function usePortfolioHoldings() {
       toggleOption,
       setToggleOption,
       toggleData,
-      showToggle: groupedRows.length > 0,
+      showToggle: !isBlocked && groupedRows.length > 0,
     },
     groupedHoldings: groupedHoldings.sort((a, b) => a.sortOrder - b.sortOrder),
     detailedHoldings: detailedHoldings.sort(

--- a/packages/features/vault/src/components/vault-leverage-slider.tsx
+++ b/packages/features/vault/src/components/vault-leverage-slider.tsx
@@ -26,10 +26,10 @@ export const VaultLeverageSlider = ({
       collateralFee,
       netRealizedDebtBalance,
       tradeType,
+      underMinAccountBorrow,
     },
   } = context;
-  const { underMinAccountBorrow, leverageRatioError, minBorrowSize } =
-    useVaultActionErrors();
+  const { leverageRatioError, minBorrowSize } = useVaultActionErrors();
   const transactionCosts = deposit
     ? (debtFee?.toToken(deposit) || TokenBalance.zero(deposit)).add(
         collateralFee?.toToken(deposit) || TokenBalance.zero(deposit)

--- a/packages/features/vault/src/hooks/use-vault-action-errors.tsx
+++ b/packages/features/vault/src/hooks/use-vault-action-errors.tsx
@@ -22,8 +22,7 @@ export function useVaultActionErrors() {
       priorAccountRisk,
     },
   } = useContext(VaultActionContext);
-  const { overCapacityError, underMinAccountBorrow, minBorrowSize } =
-    useVaultCapacity();
+  const { overCapacityError, minBorrowSize } = useVaultCapacity();
   const priorLeverageRatio = priorAccountRisk?.leverageRatio;
   const selectedLeverageRatio = riskFactorLimit?.limit as number | undefined;
 
@@ -89,7 +88,6 @@ export function useVaultActionErrors() {
   }
 
   return {
-    underMinAccountBorrow,
     minBorrowSize,
     inputErrorMsg,
     canSubmit,

--- a/packages/features/vault/src/hooks/use-vault-capacity.ts
+++ b/packages/features/vault/src/hooks/use-vault-capacity.ts
@@ -1,11 +1,11 @@
 import { useContext } from 'react';
 import { VaultActionContext } from '../vault';
-import { Registry, TokenBalance } from '@notional-finance/core-entities';
+import { Registry } from '@notional-finance/core-entities';
 import { useSelectedNetwork } from '@notional-finance/notionable-hooks';
 
 export const useVaultCapacity = () => {
   const {
-    state: { debtBalance, vaultAddress, debt, priorVaultBalances },
+    state: { debtBalance, vaultAddress },
   } = useContext(VaultActionContext);
   const network = useSelectedNetwork();
 
@@ -22,16 +22,7 @@ export const useVaultCapacity = () => {
   let capacityUsedPercentage = 0;
   let capacityWithUserBorrowPercentage: number | undefined = undefined;
   let overCapacityError = false;
-  let underMinAccountBorrow = false;
   let minBorrowSize: string | undefined = undefined;
-
-  const totalAccountDebt =
-    debt && debtBalance && debt.id === debtBalance.tokenId
-      ? (
-          priorVaultBalances?.find((t) => t.tokenId === debtBalance?.tokenId) ||
-          TokenBalance.zero(debt)
-        ).add(debtBalance)
-      : undefined;
 
   if (vaultCapacity) {
     const {
@@ -41,10 +32,6 @@ export const useVaultCapacity = () => {
     } = vaultCapacity;
 
     minBorrowSize = minAccountBorrowSize.toDisplayStringWithSymbol(0);
-    underMinAccountBorrow = totalAccountDebt?.isNegative()
-      ? totalAccountDebt.abs().toUnderlying().lt(minAccountBorrowSize)
-      : false;
-
     overCapacityError = debtBalance
       ? totalUsedPrimaryBorrowCapacity
           .add(debtBalance.toUnderlying())
@@ -69,7 +56,6 @@ export const useVaultCapacity = () => {
 
   return {
     minBorrowSize,
-    underMinAccountBorrow,
     overCapacityError,
     totalCapacityRemaining,
     maxVaultCapacity,

--- a/packages/notionable/src/base-trade/base-trade-store.ts
+++ b/packages/notionable/src/base-trade/base-trade-store.ts
@@ -104,6 +104,8 @@ interface TransactionState {
   calculationSuccess: boolean;
   /** True if the calculations are successful and the risk check has completed */
   canSubmit: boolean;
+  /** True if the vault amount is under the minimum borrow size */
+  underMinAccountBorrow?: boolean;
   /** Contains a unique key for each set of calculation inputs */
   calculateInputKeys?: string;
   /** True if the form is in the confirmation state */

--- a/packages/notionable/src/base-trade/sagas/vault-risk.ts
+++ b/packages/notionable/src/base-trade/sagas/vault-risk.ts
@@ -96,20 +96,12 @@ export function postVaultAccountRisk(
                   ) as TokenBalance[]
                 )
             : undefined;
-        const s = vaultRiskSummary(
-          prior,
-          post,
-          debtOptions?.find((t) => t.token.id === debtBalance?.tokenId)
-            ?.interestRate
-        );
 
-        const vaultCapacity =
-        network && vaultAddress
-          ? Registry.getConfigurationRegistry().getVaultCapacity(
-              network,
-              vaultAddress
-            )
-          : undefined;
+        const s = vaultRiskSummary(prior, post, debtOptions?.find((t) => t.token.id === debtBalance?.tokenId) ?.interestRate);
+
+        const vaultCapacity = network && vaultAddress ? 
+        Registry.getConfigurationRegistry().getVaultCapacity(network, vaultAddress) 
+        : undefined;
 
         let underMinAccountBorrow = false;
 
@@ -138,6 +130,7 @@ export function postVaultAccountRisk(
             account !== null && 
             underMinAccountBorrow === false &&
             inputErrors === false,
+          underMinAccountBorrow: underMinAccountBorrow,
         };
       }
     ),

--- a/packages/notionable/src/base-trade/vault-trade-manager.ts
+++ b/packages/notionable/src/base-trade/vault-trade-manager.ts
@@ -31,7 +31,7 @@ export function createVaultTradeManager(
   return merge(
     simulateTransaction(state$, account$, network$),
     buildTransaction(state$, account$),
-    postVaultAccountRisk(state$, account$),
+    postVaultAccountRisk(state$, account$, network$),
     defaultVaultLeverageRatio(state$, network$),
     priorVaultAccountRisk(state$, account$),
     availableTokens(state$, network$, account$),

--- a/packages/shared/trade/src/trade-action-button/trade-action-button.tsx
+++ b/packages/shared/trade/src/trade-action-button/trade-action-button.tsx
@@ -2,9 +2,7 @@ import { defineMessage, FormattedMessage, MessageDescriptor } from 'react-intl';
 import { NotionalTheme } from '@notional-finance/styles';
 import { useTheme, styled } from '@mui/material';
 import { Button } from '@notional-finance/mui';
-import {
-  useAccountReady,
-} from '@notional-finance/notionable-hooks';
+import { useAccountReady } from '@notional-finance/notionable-hooks';
 import { SETTINGS_SIDE_DRAWERS } from '@notional-finance/util';
 import {
   useSideDrawerState,
@@ -54,7 +52,7 @@ export function TradeActionButton({
   buttonVariant = 'contained',
   width,
   margin,
-  leverageDisabled
+  leverageDisabled,
 }: TradeActionButtonProps) {
   const theme = useTheme();
   const isAccountReady = useAccountReady();
@@ -95,8 +93,8 @@ export function TradeActionButton({
       width={width}
       margin={margin}
       variant={buttonVariant || 'contained'}
-      disabled={!isAccountReady ? false : !canSubmit}
-      canSubmit={!isAccountReady ? true : canSubmit}
+      disabled={!isAccountReady && !leverageDisabled ? false : !canSubmit}
+      canSubmit={!isAccountReady && !leverageDisabled ? true : canSubmit}
       onClick={isAccountReady ? _onSubmit : () => handleConnectWallet()}
     >
       {leverageDisabled ? (

--- a/packages/shared/web/src/header/borrow-dropdown/borrow-dropdown.tsx
+++ b/packages/shared/web/src/header/borrow-dropdown/borrow-dropdown.tsx
@@ -4,12 +4,13 @@ import { useNotionalTheme } from '@notional-finance/styles';
 import { useThemeVariant } from '@notional-finance/notionable-hooks';
 import { NAV_DROPDOWN, THEME_VARIANTS } from '@notional-finance/util';
 import { BorrowSection } from './borrow-section';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useHistory } from 'react-router-dom';
 import { CoinsIcon } from '@notional-finance/icons';
 import { messages } from '../messages';
 
 export function BorrowDropDown() {
   const { pathname } = useLocation();
+  const history = useHistory();
   const themeVariant = useThemeVariant();
 
   const flippedTheme =
@@ -29,6 +30,7 @@ export function BorrowDropDown() {
     <DropdownButton
       popupId="borrow"
       labelKey={messages[NAV_DROPDOWN.BORROW]}
+      onClick={() => history.push('/borrow-variable')}
       anchorPosition={{ top: 73, left: 0 }}
       activeTab={currentTab ? true : false}
       hideOnClick={false}

--- a/packages/shared/web/src/header/borrow-dropdown/borrow-dropdown.tsx
+++ b/packages/shared/web/src/header/borrow-dropdown/borrow-dropdown.tsx
@@ -4,13 +4,12 @@ import { useNotionalTheme } from '@notional-finance/styles';
 import { useThemeVariant } from '@notional-finance/notionable-hooks';
 import { NAV_DROPDOWN, THEME_VARIANTS } from '@notional-finance/util';
 import { BorrowSection } from './borrow-section';
-import { useLocation, useHistory } from 'react-router-dom';
+import { useLocation, Link } from 'react-router-dom';
 import { CoinsIcon } from '@notional-finance/icons';
 import { messages } from '../messages';
 
 export function BorrowDropDown() {
   const { pathname } = useLocation();
-  const history = useHistory();
   const themeVariant = useThemeVariant();
 
   const flippedTheme =
@@ -27,49 +26,50 @@ export function BorrowDropDown() {
   });
 
   return (
-    <DropdownButton
-      popupId="borrow"
-      labelKey={messages[NAV_DROPDOWN.BORROW]}
-      onClick={() => history.push('/borrow-variable')}
-      anchorPosition={{ top: 73, left: 0 }}
-      activeTab={currentTab ? true : false}
-      hideOnClick={false}
-      useStroke={true}
-      sx={{
-        textTransform: 'capitalize',
-        fontWeight: 400,
-        height: '100%',
-        padding: '6px 15px',
-      }}
-      customPopOverStyles={{
-        left: 0,
-        right: 0,
-        marginLeft: '15%',
-        marginRight: 'auto',
-        width: theme.spacing(82),
-        overflow: 'visible',
-      }}
-      icon={<CoinsIcon sx={{ fill: 'transparent', fontSize: '1.125rem' }} />}
-    >
-      <ThemeProvider theme={theme}>
-        <Box
-          sx={{
-            display: 'flex',
-            width: '100%',
-            minHeight: '450px',
-          }}
-        >
-          <BorrowSection />
-        </Box>
-        <Box
-          sx={{
-            background: theme.gradient.green,
-            height: '1px',
-            width: '100%',
-          }}
-        ></Box>
-      </ThemeProvider>
-    </DropdownButton>
+    <Link to="/borrow-variable">
+      <DropdownButton
+        popupId="borrow"
+        labelKey={messages[NAV_DROPDOWN.BORROW]}
+        anchorPosition={{ top: 73, left: 0 }}
+        activeTab={currentTab ? true : false}
+        hideOnClick={false}
+        useStroke={true}
+        sx={{
+          textTransform: 'capitalize',
+          fontWeight: 400,
+          height: '100%',
+          padding: '6px 15px',
+        }}
+        customPopOverStyles={{
+          left: 0,
+          right: 0,
+          marginLeft: '15%',
+          marginRight: 'auto',
+          width: theme.spacing(82),
+          overflow: 'visible',
+        }}
+        icon={<CoinsIcon sx={{ fill: 'transparent', fontSize: '1.125rem' }} />}
+      >
+        <ThemeProvider theme={theme}>
+          <Box
+            sx={{
+              display: 'flex',
+              width: '100%',
+              minHeight: '450px',
+            }}
+          >
+            <BorrowSection />
+          </Box>
+          <Box
+            sx={{
+              background: theme.gradient.green,
+              height: '1px',
+              width: '100%',
+            }}
+          ></Box>
+        </ThemeProvider>
+      </DropdownButton>
+    </Link>
   );
 }
 

--- a/packages/shared/web/src/header/invest-and-earn/invest-and-earn-dropdown/invest-and-earn-dropdown.tsx
+++ b/packages/shared/web/src/header/invest-and-earn/invest-and-earn-dropdown/invest-and-earn-dropdown.tsx
@@ -3,7 +3,7 @@ import { DropdownButton } from '@notional-finance/mui';
 import { useNotionalTheme } from '@notional-finance/styles';
 import { useThemeVariant } from '@notional-finance/notionable-hooks';
 import { NAV_DROPDOWN, THEME_VARIANTS } from '@notional-finance/util';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useHistory } from 'react-router-dom';
 import { BarChartIcon } from '@notional-finance/icons';
 import HighYield from '../high-yield/high-yield';
 import LowRisk from '../low-risk/low-risk';
@@ -11,6 +11,7 @@ import { messages } from '../../messages';
 
 export function InvestAndEarnDropdown() {
   const { pathname } = useLocation();
+  const history = useHistory();
   const themeVariant = useThemeVariant();
 
   const flippedTheme =
@@ -37,6 +38,7 @@ export function InvestAndEarnDropdown() {
 
   return (
     <DropdownButton
+      onClick={() => history.push('/lend-variable')}
       popupId="invest-and-earn"
       labelKey={messages[NAV_DROPDOWN.EARN_YIELD]}
       anchorPosition={{ top: 73, left: 0 }}

--- a/packages/shared/web/src/header/invest-and-earn/invest-and-earn-dropdown/invest-and-earn-dropdown.tsx
+++ b/packages/shared/web/src/header/invest-and-earn/invest-and-earn-dropdown/invest-and-earn-dropdown.tsx
@@ -3,7 +3,7 @@ import { DropdownButton } from '@notional-finance/mui';
 import { useNotionalTheme } from '@notional-finance/styles';
 import { useThemeVariant } from '@notional-finance/notionable-hooks';
 import { NAV_DROPDOWN, THEME_VARIANTS } from '@notional-finance/util';
-import { useLocation, useHistory } from 'react-router-dom';
+import { useLocation, Link } from 'react-router-dom';
 import { BarChartIcon } from '@notional-finance/icons';
 import HighYield from '../high-yield/high-yield';
 import LowRisk from '../low-risk/low-risk';
@@ -11,7 +11,6 @@ import { messages } from '../../messages';
 
 export function InvestAndEarnDropdown() {
   const { pathname } = useLocation();
-  const history = useHistory();
   const themeVariant = useThemeVariant();
 
   const flippedTheme =
@@ -37,54 +36,55 @@ export function InvestAndEarnDropdown() {
   });
 
   return (
-    <DropdownButton
-      onClick={() => history.push('/lend-variable')}
-      popupId="invest-and-earn"
-      labelKey={messages[NAV_DROPDOWN.EARN_YIELD]}
-      anchorPosition={{ top: 73, left: 0 }}
-      activeTab={currentTab ? true : false}
-      hideOnClick={false}
-      sx={{
-        textTransform: 'capitalize',
-        fontWeight: 400,
-        height: '100%',
-        padding: '6px 15px',
-      }}
-      customPopOverStyles={{
-        left: 0,
-        right: 0,
-        marginLeft: '5%',
-        marginRight: 'auto',
-        width: '950px',
-        overflow: 'visible',
-      }}
-      icon={
-        <BarChartIcon
-          className="pie-chart-icon"
-          sx={{ fontSize: '1.125rem', stroke: 'transparent', fill: 'white' }}
-        />
-      }
-    >
-      <ThemeProvider theme={theme}>
-        <Box
-          sx={{
-            display: 'flex',
-            width: '100%',
-            minHeight: '450px',
-          }}
-        >
-          <LowRisk />
-          <HighYield />
-        </Box>
-        <Box
-          sx={{
-            background: theme.gradient.green,
-            height: '1px',
-            width: '100%',
-          }}
-        ></Box>
-      </ThemeProvider>
-    </DropdownButton>
+    <Link to="/lend-variable">
+      <DropdownButton
+        popupId="invest-and-earn"
+        labelKey={messages[NAV_DROPDOWN.EARN_YIELD]}
+        anchorPosition={{ top: 73, left: 0 }}
+        activeTab={currentTab ? true : false}
+        hideOnClick={false}
+        sx={{
+          textTransform: 'capitalize',
+          fontWeight: 400,
+          height: '100%',
+          padding: '6px 15px',
+        }}
+        customPopOverStyles={{
+          left: 0,
+          right: 0,
+          marginLeft: '5%',
+          marginRight: 'auto',
+          width: '950px',
+          overflow: 'visible',
+        }}
+        icon={
+          <BarChartIcon
+            className="pie-chart-icon"
+            sx={{ fontSize: '1.125rem', stroke: 'transparent', fill: 'white' }}
+          />
+        }
+      >
+        <ThemeProvider theme={theme}>
+          <Box
+            sx={{
+              display: 'flex',
+              width: '100%',
+              minHeight: '450px',
+            }}
+          >
+            <LowRisk />
+            <HighYield />
+          </Box>
+          <Box
+            sx={{
+              background: theme.gradient.green,
+              height: '1px',
+              width: '100%',
+            }}
+          ></Box>
+        </ThemeProvider>
+      </DropdownButton>
+    </Link>
   );
 }
 


### PR DESCRIPTION
- Make the Nav Links for Borrow and Earn Yield go to the variable lend / borrow card pages
- Redirect arbitrum.notional.finance/contest to arbitrum.notional.finance
- Disable blocked vpn block button when wallet is not connected
- Under min borrow error on leveraged vaults
- Users that are blocked via VPN or US Geo should not see any "grouped tokens"