### PR TITLE
Vault apy claim simulation updates

### DIFF
--- a/apps/vault-apy/src/APYSimulator.ts
+++ b/apps/vault-apy/src/APYSimulator.ts
@@ -84,7 +84,7 @@ export default class APYSimulator {
     for (let i = 1; i <= numOfDays; i++) {
       const currentTimestamp = startingTimestamp - i * ONE_DAY_IN_SECONDS;
       log(`processing day ${i}, ${currentTimestamp}`);
-      let forkBlock = await this.#getBlockAtTimestamp(currentTimestamp);
+      const forkBlock = await this.#getBlockAtTimestamp(currentTimestamp);
 
       for (const vault of this.#config.vaults) {
         log(`Processing vault: ${vault.address}`);

--- a/apps/vault-apy/src/APYSimulator.ts
+++ b/apps/vault-apy/src/APYSimulator.ts
@@ -12,6 +12,7 @@ import {
   ConvexGaugeMainnetInterface,
   CurveGaugeInterface,
   NotionalInterface,
+  GaugeInterface,
 } from './interfaces';
 import {
   Network,
@@ -605,18 +606,11 @@ export default class APYSimulator {
       throw new Error(`Gauge address not specified for vault ${vaultAddress}`);
     }
 
-    const provider = new ethers.providers.JsonRpcProvider(this.#config.alchemyUrl);
-
-    // ABI fragment for the periodFinish variable
-    const gaugeABI = [
-      "function periodFinish() view returns (uint256)"
-    ];
-
-    const gaugeContract = new Contract(vaultData.gauge, gaugeABI, provider);
+    const gaugeContract = new Contract(vaultData.gauge, GaugeInterface, this.#alchemyProvider);
 
     try {
       // Call the periodFinish function at the specified block
-      const periodFinish: BigNumber = await gaugeContract.callStatic.periodFinish({
+      const periodFinish: BigNumber = await gaugeContract.periodFinish({
         blockTag: forkBlock
       });
       log(periodFinish.toString());

--- a/apps/vault-apy/src/index.ts
+++ b/apps/vault-apy/src/index.ts
@@ -43,7 +43,7 @@ process.on('exit', async function () {
         `processing historical apy network ${network} on date ${startOfToday.toISOString()}`
       );
 
-      await apySimulator.runHistorical(30, startOfToday);
+      await apySimulator.runHistorical(1, startOfToday);
 
       log('processing completed');
     }

--- a/apps/vault-apy/src/index.ts
+++ b/apps/vault-apy/src/index.ts
@@ -83,7 +83,38 @@ process.on('exit', async function () {
     );
 
     const apySimulator = new APYSimulator(network as Network);
-    await apySimulator.runHistoricalForVault(vaultAddress, 30, startOfToday);
+    await apySimulator.runHistoricalForVault(vaultAddress, 2, startOfToday);
+
+    log('processing completed');
+  } else if (
+    process.argv[2].toLowerCase() == 'historical-blocks' &&
+    process.argv.length >= 6
+  ) {
+    const [, , , network, vaultAddress, ...blockArgs] = process.argv;
+    if (!configPerNetwork[network]) {
+      throw new Error('Invalid network name');
+    }
+    if (
+      !configPerNetwork[network as Network].vaults.find(
+        (v) => v.address.toLowerCase() === vaultAddress.toLowerCase()
+      )
+    ) {
+      throw new Error(
+        `Vault address ${vaultAddress} does not exist in config file`
+      );
+    }
+
+    const blocks = blockArgs.map(Number);
+    if (blocks.some(isNaN)) {
+      throw new Error('Invalid block numbers provided');
+    }
+
+    log(
+      `processing historical apy for vault: ${vaultAddress} on network ${network} for specific blocks`
+    );
+
+    const apySimulator = new APYSimulator(network as Network);
+    await apySimulator.runHistoricalForVaultWithBlocks(vaultAddress, blocks);
 
     log('processing completed');
   } else {

--- a/apps/vault-apy/src/index.ts
+++ b/apps/vault-apy/src/index.ts
@@ -29,7 +29,7 @@ process.on('exit', async function () {
       log(`processing daily network ${network}`);
 
       const apySimulator = new APYSimulator(network);
-      await apySimulator.run();
+      await apySimulator.runAll();
 
       log('processing completed');
     }

--- a/apps/vault-apy/src/index.ts
+++ b/apps/vault-apy/src/index.ts
@@ -83,7 +83,7 @@ process.on('exit', async function () {
     );
 
     const apySimulator = new APYSimulator(network as Network);
-    await apySimulator.runHistoricalForVault(vaultAddress, 2, startOfToday);
+    await apySimulator.runHistoricalForVault(vaultAddress, 30, startOfToday);
 
     log('processing completed');
   } else if (

--- a/apps/vault-apy/src/interfaces.ts
+++ b/apps/vault-apy/src/interfaces.ts
@@ -112,3 +112,7 @@ export const BalancerSpotPriceInterface = new ethers.utils.Interface([
     ) external view returns (uint256[] memory balances, uint256[] memory spotPrices)
   `,
 ]);
+
+export const GaugeInterface = new ethers.utils.Interface([
+  'function periodFinish() view external returns (uint256)',
+]);


### PR DESCRIPTION
Updates the incentive claim simulation methodology to work around observed issues for Aura, ConvexMainnet, and ConvexArbitrum pools. For Aura and ConvexMainnet pools, before warping forward we check to see where the incentive accrual period finish point is and make sure we're at least one day behind it. For ConvexArbitrum pools, we make sure that we're either at least 2 hours ahead of the most recent Thursday at midnight UTC or we're at least one day behind the nearest upcoming Thursday midnight UTC.