### PR TITLE
refactor: better handle failed tx in rewarder

### DIFF
--- a/apps/rewards/rewards.http
+++ b/apps/rewards/rewards.http
@@ -3,7 +3,7 @@
 # Trigger claim or reinvest for specific vault
 # @prompt network [Network] {mainnet|arbitrum}
 # @prompt vaultAddress [Address] copy vault address from ./src/vaults.ts
-# @prompt action [Action] {claim|reinvest}
+# @prompt action [Action] {claim|reinvestment}
 # @prompt force [Boolean] {true|false}
 GET {{baseUrl}}
     ?network={{network}}

--- a/apps/rewards/tsconfig.json
+++ b/apps/rewards/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
+  "composite": true,
   "compilerOptions": {
     "lib": ["esnext"],
     "types": ["node", "@cloudflare/workers-types"]


### PR DESCRIPTION
In rewards worker, instead of saving timestamp in Cloudflare KV store, save txHash and then later check was transaction successfull before taking tx timestamp into account