### PR TITLE
fix: speed up web build ~x4

### DIFF
--- a/apps/web/project.json
+++ b/apps/web/project.json
@@ -9,6 +9,12 @@
       "executor": "@nrwl/webpack:webpack",
       "outputs": ["{options.outputPath}"],
       "defaultConfiguration": "production",
+      "dependsOn": [
+        {
+          "projects": "dependencies",
+          "target": "typechain"
+        }
+      ],
       "options": {
         "compiler": "babel",
         "outputPath": "dist/apps/web",


### PR DESCRIPTION
web:build target does not actually require building all dependecies, except for the contract:typechain task and even it can be skiped if contracts:typechain has already been run and produced files commited to git