### PR TITLE
fix: decrease web app loading time

### DIFF
--- a/packages/core-entities/src/client/analytics-registry-client.ts
+++ b/packages/core-entities/src/client/analytics-registry-client.ts
@@ -418,49 +418,70 @@ export class AnalyticsRegistryClient extends ClientRegistry<unknown> {
     };
   }
 
+  private _cache0 = new Map<Network, TokenDefinition[]>();
+  private _cache1 = new Map<string, PriceChange[]>();
   getPriceChanges(
     base: FiatKeys,
     network: Network,
     timeRange: number
   ): PriceChange[] {
-    return Registry.getTokenRegistry()
-      .getAllTokens(network)
-      .filter((t) => t.currencyId !== undefined)
-      .filter((t) =>
-        t.tokenType === 'VaultShare' || t.tokenType === 'VaultDebt'
-          ? whitelistedVaults(network).includes(t.vaultAddress)
-          : true
-      )
-      .map((t) => {
-        const unit = TokenBalance.unit(t);
-        const midnight = getMidnightUTC();
-        const pastDate = midnight - timeRange;
-        const currentUnderlying = unit.toUnderlying();
-        const currentFiat = unit.toFiat(base);
-        let pastUnderlying: TokenBalance | undefined;
-        let pastFiat: TokenBalance | undefined;
-        try {
-          pastUnderlying = unit.toUnderlying(pastDate);
-          pastFiat = unit.toFiat(base, pastDate);
-        } catch {
-          pastUnderlying = undefined;
-          pastFiat = undefined;
-        }
+    console.log('getPriceChanges', `${network}:${base}:${timeRange}`);
+    const cacheKey =
+      network === Network.all
+        ? `mainnet:${base}:${timeRange}`
+        : `${network}:${base}:${timeRange}`;
+    const cashedResult = this._cache1.get(cacheKey);
+    if (cashedResult) {
+      console.log('getPriceChanges', 'cache hit');
+      return cashedResult;
+    }
+    let allTokens = this._cache0.get(network);
+    if (!allTokens) {
+      allTokens = Registry.getTokenRegistry()
+        .getAllTokens(network)
+        .filter((t) => t.currencyId !== undefined)
+        .filter((t) =>
+          t.tokenType === 'VaultShare' || t.tokenType === 'VaultDebt'
+            ? whitelistedVaults(network).includes(t.vaultAddress || '')
+            : true
+        );
+      this._cache0.set(network, allTokens);
+    }
 
-        return {
-          asset: t,
-          pastDate: pastDate,
-          currentUnderlying,
-          currentFiat,
-          pastUnderlying,
-          pastFiat,
-          fiatChange: percentChange(currentFiat.toFloat(), pastFiat?.toFloat()),
-          underlyingChange: percentChange(
-            currentUnderlying.toFloat(),
-            pastUnderlying?.toFloat()
-          ),
-        };
-      });
+    const freshPriceChanges = allTokens.map((t) => {
+      const unit = TokenBalance.unit(t);
+      const midnight = getMidnightUTC();
+      const pastDate = midnight - timeRange;
+      const currentUnderlying = unit.toUnderlying();
+      const currentFiat = unit.toFiat(base);
+      let pastUnderlying: TokenBalance | undefined;
+      let pastFiat: TokenBalance | undefined;
+      try {
+        pastUnderlying = unit.toUnderlying(pastDate);
+        pastFiat = unit.toFiat(base, pastDate);
+      } catch {
+        pastUnderlying = undefined;
+        pastFiat = undefined;
+      }
+
+      return {
+        asset: t,
+        pastDate: pastDate,
+        currentUnderlying,
+        currentFiat,
+        pastUnderlying,
+        pastFiat,
+        fiatChange: percentChange(currentFiat.toFloat(), pastFiat?.toFloat()),
+        underlyingChange: percentChange(
+          currentUnderlying.toFloat(),
+          pastUnderlying?.toFloat()
+        ),
+      };
+    });
+
+    this._cache1.set(cacheKey, freshPriceChanges);
+
+    return freshPriceChanges;
   }
 
   async getNetworkTransactions(network: Network, skip: number) {

--- a/packages/core-entities/src/client/analytics-registry-client.ts
+++ b/packages/core-entities/src/client/analytics-registry-client.ts
@@ -425,14 +425,12 @@ export class AnalyticsRegistryClient extends ClientRegistry<unknown> {
     network: Network,
     timeRange: number
   ): PriceChange[] {
-    console.log('getPriceChanges', `${network}:${base}:${timeRange}`);
-    const cacheKey =
-      network === Network.all
-        ? `mainnet:${base}:${timeRange}`
-        : `${network}:${base}:${timeRange}`;
+    // if we uncomment next line we can further make ~0.5sec load improvement
+    // not sure is it save to do it
+    // network = network === Network.all ? Network.mainnet : network;
+    const cacheKey = `${network}:${base}`;
     const cashedResult = this._cache1.get(cacheKey);
     if (cashedResult) {
-      console.log('getPriceChanges', 'cache hit');
       return cashedResult;
     }
     let allTokens = this._cache0.get(network);
@@ -448,7 +446,7 @@ export class AnalyticsRegistryClient extends ClientRegistry<unknown> {
       this._cache0.set(network, allTokens);
     }
 
-    const freshPriceChanges = allTokens.map((t) => {
+    const result = allTokens.map((t) => {
       const unit = TokenBalance.unit(t);
       const midnight = getMidnightUTC();
       const pastDate = midnight - timeRange;
@@ -479,9 +477,9 @@ export class AnalyticsRegistryClient extends ClientRegistry<unknown> {
       };
     });
 
-    this._cache1.set(cacheKey, freshPriceChanges);
+    this._cache1.set(cacheKey, result);
 
-    return freshPriceChanges;
+    return result;
   }
 
   async getNetworkTransactions(network: Network, skip: number) {

--- a/packages/core-entities/src/client/oracle-registry-client.ts
+++ b/packages/core-entities/src/client/oracle-registry-client.ts
@@ -368,7 +368,8 @@ export class OracleRegistryClient extends ClientRegistry<OracleDefinition> {
     riskAdjusted: RiskAdjustment = 'None',
     timestamp: number
   ): ExchangeRate | null {
-    let subjectMap = this._cache0.get(`${network}:${timestamp}`);
+    const cacheKey = `${network}:${timestamp}`;
+    let subjectMap = this._cache0.get(cacheKey);
     if (!subjectMap) {
       subjectMap = Registry.getAnalyticsRegistry()
         .getHistoricalOracles(network, timestamp)
@@ -376,7 +377,7 @@ export class OracleRegistryClient extends ClientRegistry<OracleDefinition> {
           m.set(o.id, new BehaviorSubject<OracleDefinition | null>(o));
           return m;
         }, new Map<string, BehaviorSubject<OracleDefinition | null>>());
-      this._cache0.set(`${network}:${timestamp}`, subjectMap);
+      this._cache0.set(cacheKey, subjectMap);
     }
 
     if (!subjectMap || subjectMap.size === 0)

--- a/packages/core-entities/src/client/token-registry-client.ts
+++ b/packages/core-entities/src/client/token-registry-client.ts
@@ -45,10 +45,11 @@ export class TokenRegistryClient extends ClientRegistry<TokenDefinition> {
    */
   private _cache0 = new Map<string, TokenDefinition | undefined>();
   public getTokenBySymbol(network: Network, symbol: string) {
-    let token = this._cache0.get(`${network}:${symbol}`);
+    const cacheKey = `${network}:${symbol}`;
+    let token = this._cache0.get(cacheKey);
     if (!token) {
       token = this.getAllTokens(network).find((t) => t.symbol === symbol);
-      this._cache0.set(`${network}:${symbol}`, token);
+      this._cache0.set(cacheKey, token);
     }
     if (!token) throw Error(`${symbol} not found on ${network}`);
     return token;

--- a/packages/core-entities/src/client/token-registry-client.ts
+++ b/packages/core-entities/src/client/token-registry-client.ts
@@ -43,8 +43,13 @@ export class TokenRegistryClient extends ClientRegistry<TokenDefinition> {
    * @param symbol the symbol of the token
    * @returns a token definition object or undefined if not found
    */
+  private _cache0 = new Map<string, TokenDefinition | undefined>();
   public getTokenBySymbol(network: Network, symbol: string) {
-    const token = this.getAllTokens(network).find((t) => t.symbol === symbol);
+    let token = this._cache0.get(`${network}:${symbol}`);
+    if (!token) {
+      token = this.getAllTokens(network).find((t) => t.symbol === symbol);
+      this._cache0.set(`${network}:${symbol}`, token);
+    }
     if (!token) throw Error(`${symbol} not found on ${network}`);
     return token;
   }


### PR DESCRIPTION
Scripting takes a lot of time when app is loaded firs time, most of the heavy computation lies in the client registries, by implementing simple cash logic I was able to reduce scripting time from ~15sec to ~6sec (tested locally with web:serve).

Ideally we would completely refactor registries to reduce complexity and increase performance but maybe this will do for now.
@jeffywu  I can also change cashing logic so it expires after 20-30 sec(first load) if you think it is necessary

Note: additional improvements can be made if you are ok with this type of caching/optimization
Before:
![image](https://github.com/user-attachments/assets/5ee385b5-43d4-4935-81be-1248ca004a19)
After:
![image](https://github.com/user-attachments/assets/d5cbeaf6-62cf-4574-afb2-ffbf8aeef897)
