### PR TITLE
fix: sync-generic-data-errors

### DIFF
--- a/apps/data-service/src/DataService.ts
+++ b/apps/data-service/src/DataService.ts
@@ -196,7 +196,9 @@ export default class DataService {
             network_id: networkId,
           },
         ])
-        .into(DataService.TS_BN_MAPPINGS_TABLE_NAME);
+        .into(DataService.TS_BN_MAPPINGS_TABLE_NAME)
+        .onConflict(['block_number', 'network_id', 'timestamp'])
+        .ignore();
     } else {
       blockNumber = parseInt(record[0].block_number);
     }


### PR DESCRIPTION
To prevent these type of errors `error: insert into "ts_bn_mappings" ("block_number", "network_id", "timestamp")`, they happen when sync-oracle-data and sync-generic-data jobs are run concurrently [Datadog logs](https://app.datadoghq.com/logs?query=source%3Acron-service%20&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1728882575859&to_ts=1728968975859&live=true )