### PR TITLE
feat: add a few additional pieces of data to the vault-apy job

### DIFF
--- a/apps/data-service/src/DataService.ts
+++ b/apps/data-service/src/DataService.ts
@@ -605,6 +605,10 @@ export default class DataService {
               no_vault_shares: v.noVaultShares,
               swap_fees: v.swapFees,
               symbol: v.rewardTokenSymbol,
+              accumulated_reward_per_vault_share:
+                v.accumulatedRewardPerVaultShare,
+              reward_token_price_in_primary: v.rewardTokenPriceInPrimary,
+              reward_token_price_decimals: v.rewardTokenPriceDecimals,
             }))
           )
           .into(DataService.VAULT_APY_NAME)

--- a/apps/vault-apy/src/APYSimulator.ts
+++ b/apps/vault-apy/src/APYSimulator.ts
@@ -417,7 +417,7 @@ export default class APYSimulator {
         );
 
       const accumulatedRewardPerVaultShare =
-        vaultRewardStates.find(
+        (vaultRewardStates || []).find(
           (r) => r.rewardToken.toLowerCase() === token.toLowerCase()
         )?.accumulatedRewardPerVaultShare || BigNumber.from(0);
 

--- a/apps/vault-apy/src/APYSimulator.ts
+++ b/apps/vault-apy/src/APYSimulator.ts
@@ -321,7 +321,7 @@ export default class APYSimulator {
         redemptionToken.address,
         vaultData.primaryBorrowCurrency
       );
-      redemptionToken.price = price.answer.toString();
+      redemptionToken.priceInPrimary = price.answer.toString();
       redemptionToken.priceDecimals = price.decimals.toString();
     }
 
@@ -393,6 +393,19 @@ export default class APYSimulator {
         : null,
       noVaultShares: !isAccountVault,
     };
+
+    const signer = provider.getSigner(account);
+    const vaultRewardStates = await vault
+      .connect(signer)
+      .claimRewardTokens({ gasLimit: 1000000 })
+      .then((tx) => tx.wait())
+      .then(() => vault.getRewardSettings())
+      .then((rewardSettings) => rewardSettings[0])
+      .catch(() => {
+        log('No vault reward lib deployed');
+        return [];
+      });
+
     const allResults: VaultAPY[] = [];
     for (const [token, tokensClaimed] of rewardTokens) {
       const { decimals: tokenDecimals, symbol } = await getTokenDetails(
@@ -408,6 +421,11 @@ export default class APYSimulator {
             priceDecimals + tokenDecimals - primaryBorrowDecimals
           )
         );
+
+      const accumulatedRewardPerVaultShare =
+        vaultRewardStates.find(
+          (r) => r.rewardToken.toLowerCase() === token.toLowerCase()
+        )?.accumulatedRewardPerVaultShare || BigNumber.from(0);
 
       const result: VaultAPY = {
         /////////////////local log, not saved to db/////////////////////////
@@ -431,6 +449,10 @@ export default class APYSimulator {
             : '0',
         rewardTokenValuePrimaryBorrow: rewardTokenValuePrimaryBorrow.toString(),
         rewardTokenSymbol: symbol,
+        rewardTokenPriceInPrimary: priceInPrimary.toString(),
+        rewardTokenPriceDecimals: priceDecimals.toString(),
+        accumulatedRewardPerVaultShare:
+          accumulatedRewardPerVaultShare.toString(),
       };
       log(result);
       allResults.push(result);

--- a/apps/vault-apy/src/APYSimulator.ts
+++ b/apps/vault-apy/src/APYSimulator.ts
@@ -278,12 +278,6 @@ export default class APYSimulator {
     const priceOfVaultShare = await vault.getExchangeRate(0).catch(() => {
       return BigNumber.from(0);
     });
-    const totalVaultShares = await vault.callStatic
-      .getStrategyVaultInfo()
-      .then((r) => r.totalVaultShares)
-      .catch(() => {
-        return BigNumber.from(0);
-      });
 
     const block = await provider.getBlock('latest');
     // used to query defiLlama api
@@ -443,10 +437,6 @@ export default class APYSimulator {
         ...sharedData,
         rewardToken: token.toLowerCase(),
         rewardTokensClaimed: tokensClaimed.toString(),
-        rewardTokenClaimedPerVaultShare:
-          account === vaultData.address
-            ? tokensClaimed.mul(1e8).div(totalVaultShares).toString()
-            : '0',
         rewardTokenValuePrimaryBorrow: rewardTokenValuePrimaryBorrow.toString(),
         rewardTokenSymbol: symbol,
         rewardTokenPriceInPrimary: priceInPrimary.toString(),

--- a/apps/vault-apy/src/APYSimulator.ts
+++ b/apps/vault-apy/src/APYSimulator.ts
@@ -278,6 +278,12 @@ export default class APYSimulator {
     const priceOfVaultShare = await vault.getExchangeRate(0).catch(() => {
       return BigNumber.from(0);
     });
+    const totalVaultShares = await vault.callStatic
+      .getStrategyVaultInfo()
+      .then((r) => r.totalVaultShares)
+      .catch(() => {
+        return BigNumber.from(0);
+      });
 
     const block = await provider.getBlock('latest');
     // used to query defiLlama api
@@ -303,6 +309,21 @@ export default class APYSimulator {
       provider,
       account
     );
+
+    const tradingModule = new Contract(
+      this.#config.addresses.tradingModule,
+      TradingModuleInterface,
+      provider
+    );
+
+    for (const redemptionToken of RedeemDataVaultShare.redemptionTokens) {
+      const price = await tradingModule.getOraclePrice(
+        redemptionToken.address,
+        vaultData.primaryBorrowCurrency
+      );
+      redemptionToken.price = price.answer.toString();
+      redemptionToken.priceDecimals = price.decimals.toString();
+    }
 
     const redemptionData: RedemptionData = {
       vaultAddress: vaultData.address,
@@ -404,6 +425,10 @@ export default class APYSimulator {
         ...sharedData,
         rewardToken: token.toLowerCase(),
         rewardTokensClaimed: tokensClaimed.toString(),
+        rewardTokenClaimedPerVaultShare:
+          account === vaultData.address
+            ? tokensClaimed.mul(1e8).div(totalVaultShares).toString()
+            : '0',
         rewardTokenValuePrimaryBorrow: rewardTokenValuePrimaryBorrow.toString(),
         rewardTokenSymbol: symbol,
       };

--- a/apps/vault-apy/src/interfaces.ts
+++ b/apps/vault-apy/src/interfaces.ts
@@ -78,8 +78,10 @@ export const SingleSidedLPVault = new ethers.utils.Interface([
   'function name() view external returns (string)',
   'function getStrategyVaultInfo() view external returns ((address,uint8,uint256,uint256 totalVaultShares,uint256,uint256))',
   'function getExchangeRate(uint256 maturity) view external returns (int256)',
+  // VaultRewardLib
+  'function claimRewardTokens() external',
+  'function getRewardSettings() external view returns ((address rewardToken, uint32, uint32, uint128, uint128 accumulatedRewardPerVaultShare)[])',
 ]);
-
 export const TradingModuleInterface = new ethers.utils.Interface([
   'function setMaxOracleFreshness(uint32) external',
   'function NOTIONAL() external view returns (address)',

--- a/apps/vault-apy/src/interfaces.ts
+++ b/apps/vault-apy/src/interfaces.ts
@@ -83,6 +83,7 @@ export const SingleSidedLPVault = new ethers.utils.Interface([
 export const TradingModuleInterface = new ethers.utils.Interface([
   'function setMaxOracleFreshness(uint32) external',
   'function NOTIONAL() external view returns (address)',
+  'function getOraclePrice(address baseToken, address quoteToken) external view returns (int256 answer, int256 decimals)',
 ]);
 
 export const NotionalInterface = new ethers.utils.Interface([

--- a/packages/util/src/types.ts
+++ b/packages/util/src/types.ts
@@ -91,6 +91,7 @@ export type VaultAPY = {
   apy?: string;
   rewardToken: string;
   rewardTokensClaimed?: string;
+  rewardTokenClaimedPerVaultShare?: string;
   rewardTokenValuePrimaryBorrow: string;
   rewardTokenSymbol: string;
 };
@@ -100,6 +101,8 @@ export type RedemptionToken = {
   address: string;
   amountPerLpToken: string;
   decimals: number;
+  price?: string;
+  priceDecimals?: string;
 };
 
 export type RedemptionData = {

--- a/packages/util/src/types.ts
+++ b/packages/util/src/types.ts
@@ -94,6 +94,9 @@ export type VaultAPY = {
   rewardTokenClaimedPerVaultShare?: string;
   rewardTokenValuePrimaryBorrow: string;
   rewardTokenSymbol: string;
+  rewardTokenPriceInPrimary?: string;
+  rewardTokenPriceDecimals?: string;
+  accumulatedRewardPerVaultShare?: string;
 };
 
 export type RedemptionToken = {
@@ -101,7 +104,7 @@ export type RedemptionToken = {
   address: string;
   amountPerLpToken: string;
   decimals: number;
-  price?: string;
+  priceInPrimary?: string;
   priceDecimals?: string;
 };
 


### PR DESCRIPTION
Oracle rates:

Add oracle rates taken at the same block where you call getExchangeRate on the vault. Specifically, I want the oracle rate for the following tokens denominated in the borrow token of the vault:

Each token in the liquidity pool. Can ignore if the pool token == the borrow token. Each incentive token.

-- Call getOraclePrice on the trading module and input target token as baseToken and the vault borrow token as the quoteToken: https://etherscan.io/address/0x594734c7e06C3D483466ADBCe401C6Bd269746C8 https://arbiscan.io/address/0xBf6B9c5608D520469d8c4BD1E24F850497AF0Bb8

Incentive accumulators:

Add daily values of the incentive accumulators for each reward token on the vault.

Each day, simulate calling claimRewardTokens to update all accumulators. Get all the active reward tokens on the vault and save the accumulatedRewardPerVaultShare to the database for each reward token.